### PR TITLE
Remove the g-hb rule

### DIFF
--- a/chromium-dev-refresh/codesearch.css
+++ b/chromium-dev-refresh/codesearch.css
@@ -135,11 +135,6 @@ div.F-b,
 .g-Ob {
   background: #f6f6f5 !important; }
 
-/* Line highlight */
-.g-Ub,
-.g-hb {
-  background-color: #a4c9f3 !important; }
-
 /* Selection color */
 ::selection {
   background: #b8ddff !important; }


### PR DESCRIPTION
This rule was originally supposed to change line selection color, but due to layout changes in the page it instead turns most of the page blue. Removing the rule so that the page background goes back to being white.
